### PR TITLE
Fix nil pointer error when fetching project from API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-VERSION=v0.0.1
+VERSION=v0.3.2
 ARCH=amd64
 OS=darwin
 

--- a/circleci/resource_circleci_project.go
+++ b/circleci/resource_circleci_project.go
@@ -2,6 +2,7 @@ package circleci
 
 import (
 	"time"
+	"errors"
 
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -55,6 +56,10 @@ func resourceCircleCIProjectRead(d *schema.ResourceData, m interface{}) error {
 	project, err := providerClient.GetProject(projectName)
 	if err != nil {
 		return err
+	}
+
+	if project == nil {
+		return errors.New("Invalid response from CircleCI API")
 	}
 
 	if err := d.Set("name", project.Reponame); err != nil {


### PR DESCRIPTION
The CircleCI API sometimes responds with an empty 200 response, causing the provider plugin to crash:
```
Stack trace from the terraform-provider-circleci_v0.3.1 plugin:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x100 pc=0xda68e1]

goroutine 30 [running]:
github.com/mrolla/terraform-provider-circleci/circleci.resourceCircleCIProjectRead(0xc0002ff650, 0xf2d500, 0xc00017d9b0, 0xc0002ff650, 0x0)
	/Users/tomasz.cudok/projects/terraform-provider-circleci/circleci/resource_circleci_project.go:72 +0xc1
github.com/hashicorp/terraform/helper/schema.(*Resource).RefreshWithoutUpgrade(0xc0001a4880, 0xc00063d3b0, 0xf2d500, 0xc00017d9b0, 0xc00017df50, 0xc00063d3b0, 0x0)
	/Users/tomasz.cudok/go/pkg/mod/github.com/hashicorp/terraform@v0.12.0/helper/schema/resource.go:447 +0x119
github.com/hashicorp/terraform/helper/plugin.(*GRPCProviderServer).ReadResource(0xc00000e4b8, 0x123cd80, 0xc00017db90, 0xc0004e83c0, 0xc00000e4b8, 0xc00017db90, 0xc00040fbd0)
	/Users/tomasz.cudok/go/pkg/mod/github.com/hashicorp/terraform@v0.12.0/helper/plugin/grpc_provider.go:496 +0x334
github.com/hashicorp/terraform/internal/tfplugin5._Provider_ReadResource_Handler(0xfbf360, 0xc00000e4b8, 0x123cd80, 0xc00017db90, 0xc00063d270, 0x0, 0x123cd80, 0xc00017db90, 0xc00003e410, 0x49)
	/Users/tomasz.cudok/go/pkg/mod/github.com/hashicorp/terraform@v0.12.0/internal/tfplugin5/tfplugin5.pb.go:2983 +0x23e
google.golang.org/grpc.(*Server).processUnaryRPC(0xc00058ef00, 0x1248600, 0xc0004eb200, 0xc000189b00, 0xc000394d20, 0x19f4650, 0x0, 0x0, 0x0)
	/Users/tomasz.cudok/go/pkg/mod/google.golang.org/grpc@v1.18.0/server.go:966 +0x470
google.golang.org/grpc.(*Server).handleStream(0xc00058ef00, 0x1248600, 0xc0004eb200, 0xc000189b00, 0x0)
	/Users/tomasz.cudok/go/pkg/mod/google.golang.org/grpc@v1.18.0/server.go:1245 +0xd25
google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc0000d4000, 0xc00058ef00, 0x1248600, 0xc0004eb200, 0xc000189b00)
	/Users/tomasz.cudok/go/pkg/mod/google.golang.org/grpc@v1.18.0/server.go:685 +0x9f
created by google.golang.org/grpc.(*Server).serveStreams.func1
	/Users/tomasz.cudok/go/pkg/mod/google.golang.org/grpc@v1.18.0/server.go:683 +0xa1

Error: The terraform-provider-circleci_v0.3.1 plugin crashed!
```

This handles that edge case by returning an error, which should allow Terraform to retry the call.
