### PR TITLE
Fix project creation with empty GitHub repositories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-VERSION=v0.3.2
+VERSION=v0.3.3
 ARCH=amd64
 OS=darwin
 


### PR DESCRIPTION
We rely on being able to "initialise" a CircleCI project even before the corresponding GitHub repository receives its initial commit. This allows service-generator to generate empty repositories and still ensure that the CircleCI will be triggered when the changes gets pushed later.

This used to work, but it appears that a change was made to the API at some point and now if the repository is empty the API responds with a 400 error and an error message: "Branch not found".

We've been seeing this error for quite some time, assuming it was due to main/master default branch naming convention change at GitHub, but that's not the case.

Thankfully, even though the API responds with an error, the project still gets initialised in the way we need it to, so this PR simply ignores the 400 response.